### PR TITLE
Add .as_ptr() method to VolatileCell

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,12 @@ impl<T> VolatileCell<T> {
     {
         unsafe { ptr::write_volatile(self.value.get(), value) }
     }
+
+    /// Returns a raw pointer to the underlying data in the cell
+    #[inline(always)]
+    pub fn as_ptr(&self) -> *mut T {
+        self.value.get()
+    }
 }
 
 // NOTE implicit because of `UnsafeCell`


### PR DESCRIPTION
I'm working on a DMA abstraction, and this method would be helpful. It emulates the `.as_ptr()` method on `core::cell::Cell`.