### PR TITLE
Add safe bitbanding and BME support to vcell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ version = "0.1.0"
 
 [features]
 const-fn = []
+bit-manipulation = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ version = "0.1.0"
 [features]
 const-fn = []
 bit-manipulation = []
+bit-banding = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ impl<T> VolatileCell<T> {
     {
         unsafe {
             let addr = self.value.get() as usize as u32;
-            if addr & 0xe007ffff != addr {
+            if addr & 0x6007ffff != addr {
                 panic!("Tried to use BME on address 0x{:x?}, which is not in either the peripheral or upper-SRAM address range");
             }
             let bfi_addr = addr | 0x10000000 |
@@ -85,7 +85,7 @@ impl<T> VolatileCell<T> {
     {
         unsafe {
             let addr = self.value.get() as usize as u32;
-            if addr & 0xe00fffff != addr {
+            if addr & 0x600fffff != addr {
                 panic!("Tried to use BME on address 0x{:x?}, which is not in either the peripheral or upper-SRAM address range");
             }
             let bfi_addr = addr | 0x08000000;
@@ -107,7 +107,7 @@ impl<T> VolatileCell<T> {
     {
         unsafe {
             let addr = self.value.get() as usize as u32;
-            if addr & 0xe00fffff != addr {
+            if addr & 0x600fffff != addr {
                 panic!("Tried to use BME on address 0x{:x?}, which is not in either the peripheral or upper-SRAM address range");
             }
             let bfi_addr = addr | 0x04000000;
@@ -128,7 +128,7 @@ impl<T> VolatileCell<T> {
     {
         unsafe {
             let addr = self.value.get() as usize as u32;
-            if addr & 0xe00fffff != addr {
+            if addr & 0x600fffff != addr {
                 panic!("Tried to use BME on address 0x{:x?}, which is not in either the peripheral or upper-SRAM address range");
             }
             let bfi_addr = addr | 0x0c000000;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,27 @@ impl<T> VolatileCell<T> {
         }
     }
 
+    /// Inverts a collection of bits of the contained value with the bit-manipulation-engine, if
+    /// enabled.
+    /// See [NXP documentation] on the BME. This is an "XOR" operation.
+    ///
+    /// [NXP documentation]: https://www.nxp.com/docs/en/application-note/AN4838.pdf
+    #[inline(always)]
+    #[cfg(feature = "bit-manipulation")]
+    pub fn invert_bits(&self, bits_to_invert: T)
+        where T: Copy
+    {
+        unsafe {
+            let addr = self.value.get() as usize as u32;
+            if addr & 0xe00fffff != addr {
+                panic!("Tried to use BME on address 0x{:x?}, which is not in either the peripheral or upper-SRAM address range");
+            }
+            let bfi_addr = addr | 0x0c000000;
+            let bfi_ptr = bfi_addr as usize as *mut T;
+            ptr::write_volatile(bfi_ptr, bits_to_invert)
+        }
+    }
+
     /// See [ARM documentation] and [ST documentation] on bit-banding.
     ///
     /// [ARM documentation]: http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0337h/Behcjiic.html


### PR DESCRIPTION
Fixes #2 with no overhead (as long as LTO is enabled).