### PR TITLE
Implement fmt::Debug

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![no_std]
 
 use core::cell::UnsafeCell;
+use core::fmt;
 use core::ptr;
 
 /// Just like [`Cell`] but with [volatile] read / write operations
@@ -50,3 +51,11 @@ impl<T> VolatileCell<T> {
 
 // NOTE implicit because of `UnsafeCell`
 // unsafe impl<T> !Sync for VolatileCell<T> {}
+
+impl<T: Copy + fmt::Debug> fmt::Debug for VolatileCell<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VolatileCell")
+            .field("value", &self.get())
+            .finish()
+    }
+}


### PR DESCRIPTION
This implements `Debug` for `VolatileCell<T: Debug + Copy>`.

See https://github.com/rust-lang/rust/blob/1d12c3cea30b8ba4a09650a9e9c46fe9fbe25f0b/library/core/src/fmt/mod.rs#L2617-L2621.