### PR TITLE
Implement Send

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,5 +48,7 @@ impl<T> VolatileCell<T> {
     }
 }
 
+unsafe impl<T> Send for VolatileCell<T> where T: Send {}
+
 // NOTE implicit because of `UnsafeCell`
 // unsafe impl<T> !Sync for VolatileCell<T> {}


### PR DESCRIPTION
This implements `Send` for `VolatileCell<T: Send>`.

See https://github.com/rust-lang/rust/blob/1d12c3cea30b8ba4a09650a9e9c46fe9fbe25f0b/library/core/src/cell.rs#L249.